### PR TITLE
Use current Capybara wait time API

### DIFF
--- a/lib/capybara/ember/async_helpers.rb
+++ b/lib/capybara/ember/async_helpers.rb
@@ -2,7 +2,7 @@ module Capybara
   module Ember
     module AsyncHelpers
       def wait_for_ember_run_loop_to_complete
-        Capybara.default_wait_time*100.times do #this means up to 5 seconds if Capybara.default_wait_time is 5
+        Capybara.default_max_wait_time*100.times do #this means up to 5 seconds if Capybara.default_max_wait_time is 5
           return if  Capybara.current_session.evaluate_script "(typeof Ember === 'object') && !Ember.run.hasScheduledTimers() && !Ember.run.currentRunLoop"
           sleep 0.01
         end

--- a/lib/capybara/ember/version.rb
+++ b/lib/capybara/ember/version.rb
@@ -1,5 +1,5 @@
 module Capybara
   module Ember
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
This should get rid of the `DEPRECATED: #default_wait_time is deprecated, please use #default_max_wait_time instead` warnings. 
